### PR TITLE
Small updates - changing variable names and paths

### DIFF
--- a/code/analysis.R
+++ b/code/analysis.R
@@ -162,7 +162,7 @@ k <- 1 # we assume that data from k days previously is sufficient for the patien
 res_steroid <-
   progressr::with_progress(
     lmtp_sdr(
-      dat_lmtp_fix_censoring,
+      dat_lmtp,
       trt = a,
       outcome = y,
       baseline = bs,

--- a/code/report_results.R
+++ b/code/report_results.R
@@ -30,8 +30,8 @@ library(lmtp)
 
 ## read in results
 
-res_steroid <- read_rds(here::here("code/github_tutorial/res_steroid.rds"))
-res_no_steroid <- read_rds(here::here("code/github_tutorial/res_no_steroid.rds"))
+res_steroid <- read_rds(here::here("output/res_steroid.rds"))
+res_no_steroid <- read_rds(here::here("output/res_no_steroid.rds"))
 
 ## ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
There was a mistake when coding an argument to `lmtp_sdr` and also when reading the results from the calculations.